### PR TITLE
Fix: Correct parameter name in language switcher route

### DIFF
--- a/resources/views/admin/languages/index.blade.php
+++ b/resources/views/admin/languages/index.blade.php
@@ -26,7 +26,7 @@
                         <td>{{ $language['id'] }}</td>
                         <td>{{ $language['name'] }}</td>
                         <td>
-                            <a href="{{ route('lang.switch', ['lang' => $language['code']]) }}" class="btn btn-primary">Select</a>
+                            <a href="{{ route('lang.switch', ['language' => $language['code']]) }}" class="btn btn-primary">Select</a>
                         </td>
                     </tr>
                 @endforeach


### PR DESCRIPTION
- I changed `['lang' => ...]` to `['language' => ...]` in the `route('lang.switch', ...)` call within `resources/views/admin/languages/index.blade.php`.

This resolves the `UrlGenerationException` that occurred due to a mismatch between the parameter name expected by the route definition and the one provided in the view.