### PR TITLE
Fix: Correct parameter name in LanguageController@switchLang

### DIFF
--- a/app/Http/Controllers/LanguageController.php
+++ b/app/Http/Controllers/LanguageController.php
@@ -48,10 +48,10 @@ class LanguageController extends Controller
     /**
      * Get the validation rules that apply to the request.
      */
-    public function switchLang($lang): RedirectResponse
+    public function switchLang($language): RedirectResponse
     {
-        App::setLocale($lang); // Add this line
-        session()->put('applocale', $lang);
+        App::setLocale($language); // Add this line
+        session()->put('applocale', $language);
         return Redirect::back();
     }
 }


### PR DESCRIPTION
- Changed method signature from switchLang(\$lang) to switchLang(\$language).
- Updated internal variable usage from \$lang to \$language accordingly.

This ensures the method correctly receives the language code from the route parameter {language}, fixing an issue where language switching was not taking effect.