### PR TITLE
docs: fix environment spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A retreat management application written in Laravel based in part on CiviCRM
 
 ## Getting Started with Development
-We will be setting up our development envrionment in `Laravel Homestead`, a virtual machine provided by `Laravel` that meets all the system requirements needed for the Laravel framework. This will make setting up for development a breeze 💨.
+We will be setting up our development environment in `Laravel Homestead`, a virtual machine provided by `Laravel` that meets all the system requirements needed for the Laravel framework. This will make setting up for development a breeze 💨.
 
 ### Step 1: Clone the repo
 ```


### PR DESCRIPTION
## Summary
- fix a typo in README line about development environment

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842ad9c4d2483248e457257f4168fe0