### PR TITLE
Add translation keys for contacts

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -135,4 +135,10 @@ return [
     'gate_controls' => 'Gate Controls',
     'dashboards' => 'Dashboards',
     'admin' => 'Admin',
+    'persons' => 'Persons',
+    'parishes' => 'Parishes',
+    'parish' => 'Parish',
+    'dioceses' => 'Dioceses',
+    'diocese' => 'Diocese',
+    'no_dioceses_message' => 'No Dioceses are currently in the database.',
 ];

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -135,4 +135,10 @@ return [
     'gate_controls' => 'Controles de Puerta',
     'dashboards' => 'Paneles de control',
     'admin' => 'Administración',
+    'persons' => 'Personas',
+    'parishes' => 'Parroquias',
+    'parish' => 'Parroquia',
+    'dioceses' => 'Diócesis',
+    'diocese' => 'Diócesis',
+    'no_dioceses_message' => 'No hay diócesis actualmente en la base de datos.',
 ];

--- a/lang/pt/messages.php
+++ b/lang/pt/messages.php
@@ -135,4 +135,10 @@ return [
     'gate_controls' => 'Controles do Portão',
     'dashboards' => 'Painéis',
     'admin' => 'Administração',
+    'persons' => 'Pessoas',
+    'parishes' => 'Paróquias',
+    'parish' => 'Paróquia',
+    'dioceses' => 'Dioceses',
+    'diocese' => 'Diocese',
+    'no_dioceses_message' => 'Não há dioceses atualmente no banco de dados.',
 ];

--- a/resources/views/dioceses/index.blade.php
+++ b/resources/views/dioceses/index.blade.php
@@ -4,7 +4,7 @@
 <div class="row bg-cover">
     <div class="col-lg-12">
         <h1>
-            Diocese
+            {{ __('messages.diocese') }}
             @can('create-contact')
                 <span class="options">
                     <a href={{ action([\App\Http\Controllers\DioceseController::class, 'create']) }}>
@@ -18,7 +18,7 @@
     <div class="col-lg-12">
         @if ($dioceses->isEmpty())
         <div class="col-lg-12 text-center py-5">
-            <p>No Dioceses are currently in the database.</p>
+            <p>{{ __('messages.no_dioceses_message') }}</p>
         </div>
         @else
         <table class="table table-striped table-bordered table-hover table-responsive">

--- a/resources/views/parishes/index.blade.php
+++ b/resources/views/parishes/index.blade.php
@@ -3,7 +3,7 @@
     <div class="row bg-cover">
         <div class="col-lg-12">
             <h1>
-                Parish
+                {{ __('messages.parish') }}
                 @can('create-contact')
                 <span class="options">
                     <a href={{ action([\App\Http\Controllers\ParishController::class, 'create']) }}>

--- a/resources/views/persons/index.blade.php
+++ b/resources/views/persons/index.blade.php
@@ -4,7 +4,7 @@
 <div class="row bg-cover">
     <div class="col-lg-12">
         <h1>
-            Persons
+            {{ __('messages.persons') }}
             @can('create-contact')
                 <span class="options">
                     <a href={{ action([\App\Http\Controllers\PersonController::class, 'create']) }}>

--- a/resources/views/template.blade.php
+++ b/resources/views/template.blade.php
@@ -48,9 +48,9 @@
                                                         {{ __('messages.contacts') }}
 						</a>
 						<div class="dropdown-menu" aria-labelledby="navbarDropdown">
-							<a class="dropdown-item" href={{ route('person.index') }}>Persons</a>
-							<a class="dropdown-item" href={{ route('parish.index') }}>Parishes</a>
-							<a class="dropdown-item" href={{ route('diocese.index') }}>Dioceses</a>
+                                                        <a class="dropdown-item" href={{ route('person.index') }}>{{ __('messages.persons') }}</a>
+                                                        <a class="dropdown-item" href={{ route('parish.index') }}>{{ __('messages.parishes') }}</a>
+                                                        <a class="dropdown-item" href={{ route('diocese.index') }}>{{ __('messages.dioceses') }}</a>
 							<div class="dropdown-divider"></div>
 							<a class="dropdown-item" href={{ route('organization.index') }}>Organizations</a>
 							<a class="dropdown-item" href={{ route('vendor.index') }}>Vendors</a>


### PR DESCRIPTION
## Summary
- localize Persons/Parishes/Dioceses menu labels and headings
- add translations for the new keys in English, Spanish and Portuguese

## Testing
- `phpunit` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68436603484c8324ad871477bbd897d5