### PR TITLE
Fix language attribute to use session locale

### DIFF
--- a/resources/views/template.blade.php
+++ b/resources/views/template.blade.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ session('applocale', config('app.locale')) }}">
 
 <head>
 	<meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- update `<html>` tag to reflect user's language selection stored in session

## Testing
- `composer install` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6843660f9b788324aa911302e6fc33c9