### PR TITLE
Fix sched2 HTML row loop

### DIFF
--- a/resources/views/rooms/sched2.blade.php
+++ b/resources/views/rooms/sched2.blade.php
@@ -39,12 +39,12 @@
                     @else
                         
                         @foreach($roomsort as $room)
-                    
+
                         <tr>
                             <th scope="row">
                                 <a href="{{url('room/'.$room->id)}}">{{$room->location->name}} {{$room->name}}</a>
                             </th>
-                            
+
                             @foreach($dts as $dt)
                                 @if (($m[$room->id][$dt->toDateString()]['status'] == 'R') OR ($m[$room->id][$dt->toDateString()]['status'] == 'O')) 
                                 <td class="table-warning">
@@ -55,8 +55,8 @@
                                 @endif
                                 </td>
                             @endforeach
-                        @endforeach
                         </tr>
+                        @endforeach
     
                         
                     @endif


### PR DESCRIPTION
## Summary
- fix closing `<tr>` position so each room row is properly closed

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438b899bac8324bc62a43ab839794c