### PR TITLE
Auto-generate Retreat idnumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Prior to committing code changes, it is suggested to run the phpunit tests. Test
 
 * php artisan --env=testing migrate:fresh --seed
 * php artisan --env=testing db:seed --class=TestPermissionRolesSeeder
+
+## Retreat ID numbers
+
+When creating a retreat the ID number is generated automatically. The next value
+is determined by incrementing the highest numeric portion of existing retreat
+IDs. The generated number is shown on the creation form and cannot be edited.
 ## Localization
 
 Polanco supports multiple interface languages.

--- a/app/Http/Controllers/RetreatController.php
+++ b/app/Http/Controllers/RetreatController.php
@@ -112,7 +112,9 @@ class RetreatController extends Controller
             $c = [0 => 'N/A'] + $c;
         }
 
-        return view('retreats.create', compact('d', 'i', 'a', 'c', 'event_types', 'is_active'));
+        $next_idnumber = \App\Models\Retreat::nextIdnumber();
+
+        return view('retreats.create', compact('d', 'i', 'a', 'c', 'event_types', 'is_active', 'next_idnumber'));
     }
 
     /**
@@ -124,7 +126,7 @@ class RetreatController extends Controller
 
         $retreat = new \App\Models\Retreat;
 
-        $retreat->idnumber = $request->input('idnumber');
+        $retreat->idnumber = \App\Models\Retreat::nextIdnumber();
         $retreat->start_date = $request->input('start_date');
         $retreat->end_date = $request->input('end_date');
         $retreat->title = $request->input('title');

--- a/app/Models/Retreat.php
+++ b/app/Models/Retreat.php
@@ -29,6 +29,23 @@ class Retreat extends Model implements Auditable
         ];
     }
 
+    /**
+     * Generate the next sequential idnumber based on existing numeric values.
+     */
+    public static function nextIdnumber(): string
+    {
+        $max = self::pluck('idnumber')
+            ->map(function ($id) {
+                if (preg_match('/^\d+/', $id, $m)) {
+                    return (int) $m[0];
+                }
+
+                return 0;
+            })->max();
+
+        return (string) (($max ?? 0) + 1);
+    }
+
     public function setStartDateAttribute($date)
     {
         $this->attributes['start_date'] = Carbon::parse($date);

--- a/resources/views/retreats/create.blade.php
+++ b/resources/views/retreats/create.blade.php
@@ -11,7 +11,7 @@
                 <div class="row">
                     <div class="col-lg-3">
                         {{ html()->label('ID#:', 'idnumber') }}
-                        {{ html()->text('idnumber')->class('form-control') }}
+                        {{ html()->text('idnumber', $next_idnumber)->class('form-control')->attribute('readonly', true) }}
                     </div>
                     <div class="col-lg-3">
                         {{ html()->label('Title: ', 'title') }}

--- a/tests/Feature/Http/Controllers/RetreatControllerTest.php
+++ b/tests/Feature/Http/Controllers/RetreatControllerTest.php
@@ -117,6 +117,7 @@ final class RetreatControllerTest extends TestCase
     {
         $user = $this->createUserWithPermission('create-retreat');
 
+        $expected = \App\Models\Retreat::nextIdnumber();
         $response = $this->actingAs($user)->get(route('retreat.create'));
         $response->assertOk();
         $response->assertViewIs('retreats.create');
@@ -126,7 +127,9 @@ final class RetreatControllerTest extends TestCase
         $response->assertViewHas('c');
         $response->assertViewHas('event_types');
         $response->assertViewHas('is_active');
+        $response->assertViewHas('next_idnumber');
         $response->assertSeeText('Create Retreat');
+        $response->assertSeeText($expected);
     }
 
     #[Test]
@@ -379,9 +382,9 @@ final class RetreatControllerTest extends TestCase
     public function store_returns_an_ok_response(): void
     {
         $user = $this->createUserWithPermission('create-retreat');
-        $idnumber = $this->faker->numberBetween(11111111, 99999999).$this->faker->lastName();
+        $expected = \App\Models\Retreat::nextIdnumber();
         $response = $this->actingAs($user)->post(route('retreat.store'), [
-            'idnumber' => $idnumber,
+            'idnumber' => 'ignored',
             'start_date' => Carbon::parse($this->faker->dateTimeBetween('+6 days', '+10 days')),
             'end_date' => Carbon::parse($this->faker->dateTimeBetween('+11 days', '+15 days')),
             'title' => $this->faker->catchPhrase(),
@@ -393,10 +396,10 @@ final class RetreatControllerTest extends TestCase
             'assistant_id' => 0,
         ]);
         // TODO: assumes that Google calendar integration is not set but eventually we will want to test that this too is working and saving the calendar event
-        $retreat = \App\Models\Retreat::whereIdnumber($idnumber)->first();
+        $retreat = \App\Models\Retreat::whereIdnumber($expected)->first();
         $response->assertSessionHas('flash_notification');
         $response->assertRedirect(action([\App\Http\Controllers\RetreatController::class, 'index']));
-        $this->assertEquals($retreat->idnumber, $idnumber);
+        $this->assertEquals($retreat->idnumber, $expected);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- add `Retreat::nextIdnumber()` helper
- prepopulate the retreat ID field in the form
- ignore submitted `idnumber` when storing
- adjust feature tests
- document automatic IDs in README

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457a9d36c08324b056fb45f02b8128