### PR TITLE
Implement select2 filter and drag-and-drop schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,9 @@ The `config:clear` command reloads the configuration so the new default takes ef
 ### Switching languages at runtime
 
 A **Language** dropdown is available in the top navigation bar. Choose a language from this menu to update the interface instantly. The selected locale is stored in your session and will be used for subsequent pages.
+
+## Room Schedule
+
+Polanco includes a monthly room schedule available at `/rooms`. This page renders a matrix of rooms versus days and highlights reserved or occupied dates. You can view other months by appending a date in `YYYYMMDD` format to the URL. For example, `/rooms/20250101` shows January&nbsp;2025.
+
+The schedule logic is implemented in `RoomController::schedule`.

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\UpdateRoomRequest;
 use Carbon\Carbon;
 use DateTime;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
 
@@ -324,5 +325,16 @@ class RoomController extends Controller
         $d = DateTime::createFromFormat($format, $date);
 
         return $d && $d->format($format) == $date;
+    }
+
+    public function moveReservation(Request $request)
+    {
+        $this->authorize('update-registration');
+
+        $registration = \App\Models\Registration::findOrFail($request->input('registration_id'));
+        $registration->room_id = $request->input('room_id');
+        $registration->save();
+
+        return response()->json(['status' => 'ok']);
     }
 }

--- a/resources/assets/js/main.js
+++ b/resources/assets/js/main.js
@@ -26,4 +26,29 @@ $(document).ready(function() {
   $('.flatpickr-date').flatpickr(dateOptions); // Apply flatpickr
   $('.flatpickr-date-time').flatpickr(dateTimeOptions);
   $('.flatpickr-time').flatpickr(timeOptions);
+
+  // Enable drag & drop of reservations on the room schedule
+  $('.reservation').draggable({
+    revert: 'invalid',
+    helper: 'clone'
+  });
+
+  $('.room-cell').droppable({
+    accept: '.reservation',
+    hoverClass: 'table-primary',
+    drop: function (event, ui) {
+      const registrationId = ui.draggable.data('registration-id');
+      const roomId = $(this).data('room-id');
+      const date = $(this).data('date');
+      $.ajax({
+        url: '/rooms/move-reservation',
+        method: 'POST',
+        data: {
+          registration_id: registrationId,
+          room_id: roomId,
+          date: date
+        }
+      });
+    }
+  });
 });

--- a/resources/views/rooms/index.blade.php
+++ b/resources/views/rooms/index.blade.php
@@ -16,7 +16,7 @@
                         @endCan
                     </h1>
 
-                    <select class="location-select" onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                    <select class="location-select select2" onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
                         <option value="">Filter by building ...</option>
                         <option value="{{url('room')}}">All buildings</option>
                         @foreach($locations as $key=>$location)

--- a/resources/views/rooms/sched2.blade.php
+++ b/resources/views/rooms/sched2.blade.php
@@ -47,10 +47,10 @@
 
                             @foreach($dts as $dt)
                                 @if (($m[$room->id][$dt->toDateString()]['status'] == 'R') OR ($m[$room->id][$dt->toDateString()]['status'] == 'O')) 
-                                <td class="table-warning">
-                                {{ html()->a(url('registration/' . $m[$room->id][$dt->toDateString()]['registration_id']), $m[$room->id][$dt->toDateString()]['status'])->attribute('title', $m[$room->id][$dt->toDateString()]['retreat_name'] . ' (' . $m[$room->id][$dt->toDateString()]['retreatant_name'] . ')') }} 
+                                <td class="table-warning room-cell" data-room-id="{{$room->id}}" data-date="{{$dt->toDateString()}}">
+                                {{ html()->a(url('registration/' . $m[$room->id][$dt->toDateString()]['registration_id']), $m[$room->id][$dt->toDateString()]['status'])->attribute('title', $m[$room->id][$dt->toDateString()]['retreat_name'] . ' (' . $m[$room->id][$dt->toDateString()]['retreatant_name'] . ')')->attribute('class', 'reservation')->attribute('data-registration-id', $m[$room->id][$dt->toDateString()]['registration_id']) }}
                                 @else
-                                <td class="table-success">
+                                <td class="table-success room-cell" data-room-id="{{$room->id}}" data-date="{{$dt->toDateString()}}">
                                     A
                                 @endif
                                 </td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -352,6 +352,7 @@ Route::middleware('web', 'activity')->group(function () {
     Route::get('room/location/{location_id?}', [RoomController::class, 'index_location']);
     Route::resource('room', RoomController::class);
     Route::get('rooms/{ymd?}', [RoomController::class, 'schedule'])->name('rooms');
+    Route::post('rooms/move-reservation', [RoomController::class, 'moveReservation'])->name('rooms.move-reservation');
 
     Route::name('squarespace.')->prefix('squarespace')->group(function () {
         Route::resource('/', SquarespaceController::class);

--- a/tests/Feature/Http/Controllers/RoomControllerTest.php
+++ b/tests/Feature/Http/Controllers/RoomControllerTest.php
@@ -263,5 +263,24 @@ final class RoomControllerTest extends TestCase
         );
     }
 
+    #[Test]
+    public function move_reservation_updates_the_room(): void
+    {
+        $user = $this->createUserWithPermission('update-registration');
+        $roomA = \App\Models\Room::factory()->create();
+        $roomB = \App\Models\Room::factory()->create();
+        $registration = \App\Models\Registration::factory()->create(['room_id' => $roomA->id]);
+
+        $response = $this->actingAs($user)->post(route('rooms.move-reservation'), [
+            'registration_id' => $registration->id,
+            'room_id' => $roomB->id,
+            'date' => now()->toDateString(),
+        ]);
+
+        $response->assertJson(['status' => 'ok']);
+        $registration->refresh();
+        $this->assertEquals($roomB->id, $registration->room_id);
+    }
+
     // test cases...
 }


### PR DESCRIPTION
## Summary
- enhance building filter with Select2
- document room schedule view in README
- allow room cells to accept drag-and-drop reservations
- add route and controller method to update a moved reservation
- test reservation move logic

## Testing
- `npm run dev`
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583e1091b4832499e308fcd1a65f9d