### PR TITLE
Add CSRF setup for ajax requests

### DIFF
--- a/resources/assets/js/main.js
+++ b/resources/assets/js/main.js
@@ -27,6 +27,10 @@ $(document).ready(function() {
   $('.flatpickr-date-time').flatpickr(dateTimeOptions);
   $('.flatpickr-time').flatpickr(timeOptions);
 
+  $.ajaxSetup({
+    headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')}
+  });
+
   // Enable drag & drop of reservations on the room schedule
   $('.reservation').draggable({
     revert: 'invalid',


### PR DESCRIPTION
## Summary
- configure jQuery ajax with CSRF token

## Testing
- `npm run dev`
- `vendor/bin/phpunit tests/Feature/Http/Controllers/RoomControllerTest.php --filter move_reservation_updates_the_room` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68587a575f7c8324ba36706385675257