### PR TITLE
Add reservation modal to room schedule

### DIFF
--- a/resources/assets/js/main.js
+++ b/resources/assets/js/main.js
@@ -27,6 +27,11 @@ $(document).ready(function() {
   $('.flatpickr-date-time').flatpickr(dateTimeOptions);
   $('.flatpickr-time').flatpickr(timeOptions);
 
+  const reservationModal = $('#reservationModal');
+  const roomInput = $('#reservation-room-id');
+  const startInput = $('#reservation-start-date');
+  const endInput = $('#reservation-end-date');
+
   $.ajaxSetup({
     headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')}
   });
@@ -61,6 +66,17 @@ $(document).ready(function() {
   let startCell = null;
   let selectedCells = [];
 
+  // Click on a single available cell to open reservation modal
+  $('.room-cell.table-success').on('click', function () {
+    if (selecting) return;
+    const roomId = $(this).data('room-id');
+    const date = $(this).data('date');
+    roomInput.val(roomId);
+    startInput.val(date);
+    endInput.val(date);
+    reservationModal.modal('show');
+  });
+
   $('.room-cell.table-success')
     .on('mousedown', function (e) {
       selecting = true;
@@ -87,21 +103,12 @@ $(document).ready(function() {
     const startDate = $(selectedCells[0]).data('date');
     const endDate = $(selectedCells[selectedCells.length - 1]).data('date');
 
-    $.ajax({
-      url: '/rooms/create-reservation',
-      method: 'POST',
-      headers: {
-        'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
-      },
-      data: {
-        room_id: roomId,
-        start_date: startDate,
-        end_date: endDate
-      },
-      complete: function () {
-        $(selectedCells).removeClass('table-info');
-        selecting = false;
-      }
-    });
+    roomInput.val(roomId);
+    startInput.val(startDate);
+    endInput.val(endDate);
+    reservationModal.modal('show');
+
+    $(selectedCells).removeClass('table-info');
+    selecting = false;
   });
 });

--- a/resources/views/rooms/sched2.blade.php
+++ b/resources/views/rooms/sched2.blade.php
@@ -73,6 +73,37 @@
     </div>
 </div>
 
+<!-- Reservation Modal -->
+<div class="modal fade" id="reservationModal" tabindex="-1" role="dialog" aria-labelledby="reservationModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="reservationModalLabel">Add Reservation</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                {{ html()->form('POST', route('rooms.create-reservation'))->id('reservationForm')->open() }}
+                    {{ html()->hidden('room_id')->id('reservation-room-id') }}
+                    <div class="form-group">
+                        {{ html()->label('Start Date', 'reservation-start-date') }}
+                        {{ html()->text('start_date')->class('form-control flatpickr-date')->id('reservation-start-date') }}
+                    </div>
+                    <div class="form-group">
+                        {{ html()->label('End Date', 'reservation-end-date') }}
+                        {{ html()->text('end_date')->class('form-control flatpickr-date')->id('reservation-end-date') }}
+                    </div>
+                {{ html()->form()->close() }}
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <button type="submit" class="btn btn-primary" form="reservationForm">Save</button>
+            </div>
+        </div>
+    </div>
+</div>
+
     {{-- <section class="section-padding">
         <div class="jumbotron text-left">
             <div class="panel panel-default">

--- a/tests/Feature/Http/Controllers/RoomControllerTest.php
+++ b/tests/Feature/Http/Controllers/RoomControllerTest.php
@@ -175,6 +175,18 @@ final class RoomControllerTest extends TestCase
     }
 
     #[Test]
+    public function schedule_contains_reservation_modal(): void
+    {
+        $user = $this->createUserWithPermission('show-room');
+
+        $response = $this->actingAs($user)->get(route('rooms'));
+
+        $response->assertOk();
+        $response->assertSee('id="reservationModal"', false);
+        $response->assertSee('id="reservationForm"', false);
+    }
+
+    #[Test]
     public function show_returns_an_ok_response(): void
     {
         $user = $this->createUserWithPermission('show-room');


### PR DESCRIPTION
## Summary
- add a modal form for quick reservations on the room schedule
- open the modal from available cells with JS
- allow drag selection of multiple cells to pre-fill dates
- test that the modal exists on the schedule page
- compile assets

## Testing
- `npm run prod`
- `vendor/bin/phpunit --stop-on-failure` *(fails: `vendor/bin/phpunit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588852c19883248d5e1accb6f0c43b