### PR TITLE
Fix duplicate modal after drag selection

### DIFF
--- a/resources/assets/js/main.js
+++ b/resources/assets/js/main.js
@@ -31,6 +31,11 @@ $(document).ready(function() {
   const roomInput = $('#reservation-room-id');
   const startInput = $('#reservation-start-date');
   const endInput = $('#reservation-end-date');
+  let wasSelecting = false;
+
+  reservationModal.on('shown.bs.modal', function () {
+    wasSelecting = false;
+  });
 
   $.ajaxSetup({
     headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')}
@@ -68,7 +73,7 @@ $(document).ready(function() {
 
   // Click on a single available cell to open reservation modal
   $('.room-cell.table-success').on('click', function () {
-    if (selecting) return;
+    if (selecting || wasSelecting) return;
     const roomId = $(this).data('room-id');
     const date = $(this).data('date');
     roomInput.val(roomId);
@@ -107,6 +112,7 @@ $(document).ready(function() {
     startInput.val(startDate);
     endInput.val(endDate);
     reservationModal.modal('show');
+    wasSelecting = true;
 
     $(selectedCells).removeClass('table-info');
     selecting = false;


### PR DESCRIPTION
## Summary
- prevent click handler from reopening reservation modal after a drag selection
- track when drag selection occurred and reset once modal appears
- compile assets with `npm run prod`

## Testing
- `npm run prod`


------
https://chatgpt.com/codex/tasks/task_e_68591c10802c83248f1a5f22eed01b7f