### PR TITLE
Fix missing brace in RoomControllerTest

### DIFF
--- a/tests/Feature/Http/Controllers/RoomControllerTest.php
+++ b/tests/Feature/Http/Controllers/RoomControllerTest.php
@@ -317,6 +317,8 @@ final class RoomControllerTest extends TestCase
             'room_id' => $room->id,
         ]);
 
+    }
+
     public function move_reservation_returns_error_on_conflict(): void
     {
         $user = $this->createUserWithPermission('update-registration');


### PR DESCRIPTION
## Summary
- close the `create_reservation_creates_a_registration` test method

## Testing
- `./vendor/bin/phpunit` *(fails: Database file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68591c0f0be48324a12285eaa176056e