### PR TITLE
Fix calendar embed to use env config

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,9 +6,9 @@
 		<p><a href="https://en.wikipedia.org/wiki/Juan_Alfonso_de_Polanco" target="_blank">{{ __('messages.polanco') }}</a> {{ __('messages.polanco_description') }}</p>
 		<p><a href="https://www.liturgia.pt/liturgiadiaria/" target="_blank">{{ __('messages.todays_readings') }}</a></p>
 <!--		<p>{!! $quote !!}</p>  -->
-		<div class="responsiveCal">
-			<iframe src="https://calendar.google.com/calendar/embed?wkst=2&amp;bgcolor=%23FFFFFF&amp;src=montserratretreat.org_6rll8gg5fu0tmps7riubl0g0cc%40group.calendar.google.com&amp;color=%23711616&amp;ctz=America%2FChicago" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-		</div>
+                <div class="responsiveCal">
+                        <iframe src="https://calendar.google.com/calendar/embed?wkst=2&amp;bgcolor=%23FFFFFF&amp;src={{ rawurlencode(config('google-calendar.calendar_id')) }}&amp;color=%23711616&amp;ctz=America%2FChicago" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+                </div>
 	</div>
 </div>
 @stop


### PR DESCRIPTION
## Summary
- use `GOOGLE_CALENDAR_ID` when embedding calendar in the welcome page

## Testing
- `composer install --no-interaction --no-progress` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591b709a188324bf607aa885eda260