### PR TITLE
Fix config gate section in PageController

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -467,6 +467,10 @@ class PageController extends Controller
     {
         $this->authorize('show-admin-menu');
 
+        return view('admin.config.gate');
+    }
+
+    public function config_google_client(): View
     {
         $this->authorize('show-admin-menu');
 


### PR DESCRIPTION
## Summary
- restore `config_gate()` and `config_google_client()` in `PageController`
- verify PHP syntax

## Testing
- `php -l app/Http/Controllers/PageController.php`


------
https://chatgpt.com/codex/tasks/task_e_6872f5f25c788324a5655628a35dff4d