### PR TITLE
Remove Google Calendar integration

### DIFF
--- a/resources/views/retreats/edit.blade.php
+++ b/resources/views/retreats/edit.blade.php
@@ -47,10 +47,6 @@
                             {{ html()->label('Maximum participants', 'max_participants') }}
                             {{ html()->text('max_participants', $retreat->max_participants)->class('form-control') }}
                         </div>
-                        <div class="col-lg-3">
-                            {{ html()->label('Google Calendar ID:', 'calendar_id') }}
-                            {{ html()->text('calendar_id', $retreat->calendar_id)->class('form-control')->isReadonly() }}
-                        </div>
                     </div>
                     <div class="row"> <!-- Adicionar aqui uma lista definida nos buildings, que vai ler o evento -->
                     <div class="col-lg-3"> <!-- Algo deste genero {{ html()->select('event_type', $event_types, $retreat->event_type_id)->class('form-control') }} -->

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,9 +6,8 @@
 		<p><a href="https://en.wikipedia.org/wiki/Juan_Alfonso_de_Polanco" target="_blank">{{ __('messages.polanco') }}</a> {{ __('messages.polanco_description') }}</p>
 		<p><a href="https://www.liturgia.pt/liturgiadiaria/" target="_blank">{{ __('messages.todays_readings') }}</a></p>
 <!--		<p>{!! $quote !!}</p>  -->
-                <div class="responsiveCal">
-                        <iframe src="https://calendar.google.com/calendar/embed?wkst=2&amp;bgcolor=%23FFFFFF&amp;src={{ rawurlencode(config('google-calendar.calendar_id')) }}&amp;color=%23711616&amp;ctz=America%2FChicago" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-                </div>
-	</div>
+                <div id="calendar"></div>
+        </div>
 </div>
 @stop
+<script src="{{ url(mix('dist/calendar.js')) }}"></script>


### PR DESCRIPTION
## Summary
- remove Google Calendar iframe from welcome page
- use FullCalendar script instead
- drop Google Calendar ID field from retreat editor

## Testing
- `vendor/bin/phpunit` *(fails: Attribute "Test" must not be repeated)*

------
https://chatgpt.com/codex/tasks/task_e_687276e7c8088324a62f3e2e0f754a13