### PR TITLE
Clean up tests after calendar refactor

### DIFF
--- a/tests/Feature/Http/Controllers/PageControllerTest.php
+++ b/tests/Feature/Http/Controllers/PageControllerTest.php
@@ -12,7 +12,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
-//TODO: Create unit tests for new admin.config pages (index, mail, google_calendar, etc.)
+//TODO: Create unit tests for new admin.config pages (index, mail, etc.)
 
 /**
  * @see \App\Http\Controllers\PageController
@@ -121,25 +121,6 @@ final class PageControllerTest extends TestCase
         $user = \App\Models\User::factory()->create();
 
         $response = $this->actingAs($user)->get(route('admin.config.gate'));
-        $response->assertForbidden();
-    }
-    #[Test]
-    public function config_google_client_returns_an_ok_response(): void
-    {
-        $user = $this->createUserWithPermission('show-admin-menu');
-
-        $response = $this->actingAs($user)->get(route('admin.config.google_client'));
-
-        $response->assertOk();
-        $response->assertViewIs('admin.config.google_client');
-    }
-
-    #[Test]
-    public function config_google_client_returns_403(): void
-    {
-        $user = \App\Models\User::factory()->create();
-
-        $response = $this->actingAs($user)->get(route('admin.config.google_client'));
         $response->assertForbidden();
     }
 

--- a/tests/Feature/Http/Controllers/RetreatControllerTest.php
+++ b/tests/Feature/Http/Controllers/RetreatControllerTest.php
@@ -45,8 +45,6 @@ final class RetreatControllerTest extends TestCase
     }
 
     #[Test]
-
-    #[Test]
     public function checkin_returns_an_ok_response(): void
     {
         $user = $this->createUserWithPermission('update-registration');


### PR DESCRIPTION
## Summary
- drop references to removed Google Calendar pages
- clean up duplicate test attributes

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml --stop-on-failure` *(fails: Please provide a valid cache path)*

------
https://chatgpt.com/codex/tasks/task_e_687276ebdb7c8324803974c354c0c4fd