### PR TITLE
Add schedule translations

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -265,4 +265,13 @@ return [
     'export_list_added' => 'Export list: <a href=":url">:label</a> added',
     'export_list_updated' => 'Export list: <a href=":url">:label</a> updated',
     'export_list_deleted' => 'Export list: :label deleted',
+    'room_schedules_for' => 'Room Schedules for :start - :end',
+    'legend_title' => 'Legend:',
+    'legend_available' => 'A=Available',
+    'legend_reserved' => 'R=Reserved',
+    'legend_occupied' => 'O=Occupied',
+    'legend_cleaning_needed' => 'C=Cleaning Needed',
+    'legend_maintenance_required' => 'M=Maintenance Required',
+    'yikes_nothing_to_schedule_message' => 'Yikes, there is nothing to schedule!',
+    'yikes_no_rooms_message' => 'Yikes, there are no rooms!',
 ];

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -265,4 +265,13 @@ return [
     'export_list_added' => 'Lista de exportación: <a href=":url">:label</a> añadida',
     'export_list_updated' => 'Lista de exportación: <a href=":url">:label</a> actualizada',
     'export_list_deleted' => 'Lista de exportación: :label eliminada',
+    'room_schedules_for' => 'Horarios de habitaciones para :start - :end',
+    'legend_title' => 'Leyenda:',
+    'legend_available' => 'A=Disponible',
+    'legend_reserved' => 'R=Reservado',
+    'legend_occupied' => 'O=Ocupado',
+    'legend_cleaning_needed' => 'C=Limpieza Necesaria',
+    'legend_maintenance_required' => 'M=Mantenimiento Requerido',
+    'yikes_nothing_to_schedule_message' => '¡Vaya, no hay nada para programar!',
+    'yikes_no_rooms_message' => '¡Vaya, no hay habitaciones!',
 ];

--- a/lang/pt/messages.php
+++ b/lang/pt/messages.php
@@ -265,4 +265,13 @@ return [
     'export_list_added' => 'Lista de exportação: <a href=":url">:label</a> adicionada',
     'export_list_updated' => 'Lista de exportação: <a href=":url">:label</a> atualizada',
     'export_list_deleted' => 'Lista de exportação: :label excluída',
+    'room_schedules_for' => 'Programação de quartos para :start - :end',
+    'legend_title' => 'Legenda:',
+    'legend_available' => 'A=Disponível',
+    'legend_reserved' => 'R=Reservado',
+    'legend_occupied' => 'O=Ocupado',
+    'legend_cleaning_needed' => 'C=Limpeza Necessária',
+    'legend_maintenance_required' => 'M=Manutenção Necessária',
+    'yikes_nothing_to_schedule_message' => 'Eita, não há nada para agendar!',
+    'yikes_no_rooms_message' => 'Eita, não há quartos!',
 ];

--- a/resources/views/rooms/schedule.blade.php
+++ b/resources/views/rooms/schedule.blade.php
@@ -8,19 +8,19 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <h1>
-                    <span class="grey">Room Schedules for {{$dts[0]->format('F d, Y')}} - {{$dts[31]->format('F d, Y')}} </span>
+                    <span class="grey">{{ __('messages.room_schedules_for', ['start' => $dts[0]->format('F d, Y'), 'end' => $dts[31]->format('F d, Y')]) }}</span>
                     </div>
 
                 @if (empty($dts))
-                    <p> Yikes, there is nothing to schedule!</p>
+                    <p>{{ __('messages.yikes_nothing_to_schedule_message') }}</p>
                 @else
                 <table border="1" class="table">
-                        <caption><h2>Legend:
-                            <span style="background-color:#dff0d8">A=Available</span>;
-                            <span style="background-color:#fcf8e3">R=Reserved</span>;
-                            <span style="background-color:#fcf8e3">O=Occupied</span>;
-                            <span style="background-color:#f2dede">C=Cleaning Needed</span>;
-                            <span style="background-color:#f2dede">M=Maintenance Required</span>
+                        <caption><h2>{{ __('messages.legend_title') }}
+                            <span style="background-color:#dff0d8">{{ __('messages.legend_available') }}</span>;
+                            <span style="background-color:#fcf8e3">{{ __('messages.legend_reserved') }}</span>;
+                            <span style="background-color:#fcf8e3">{{ __('messages.legend_occupied') }}</span>;
+                            <span style="background-color:#f2dede">{{ __('messages.legend_cleaning_needed') }}</span>;
+                            <span style="background-color:#f2dede">{{ __('messages.legend_maintenance_required') }}</span>
                         </h2></caption>
                     <thead>
                         <tr>
@@ -33,7 +33,7 @@
                     </thead>
                     <tbody>
                         @if ($roomsort->isEmpty())
-                            <p> Yikes, there are no rooms!</p>
+                            <p>{{ __('messages.yikes_no_rooms_message') }}</p>
                         @else
 
                             @foreach($roomsort as $room)


### PR DESCRIPTION
## Summary
- add missing translations for schedule headings and yikes messages
- wire translations into the schedule view

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit` *(fails: Database file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68740c1c8b0c8324a3f4728b8fd1c661