### PR TITLE
Enhance room reservation modal

### DIFF
--- a/resources/assets/js/main.js
+++ b/resources/assets/js/main.js
@@ -117,4 +117,16 @@ $(document).ready(function() {
     $(selectedCells).removeClass('table-info');
     selecting = false;
   });
+
+  $('#reservationForm').on('submit', function (e) {
+    e.preventDefault();
+    $.post({
+      url: $(this).attr('action'),
+      data: $(this).serialize(),
+      success: function () {
+        reservationModal.modal('hide');
+        window.location.reload();
+      }
+    });
+  });
 });

--- a/resources/views/rooms/sched2.blade.php
+++ b/resources/views/rooms/sched2.blade.php
@@ -94,6 +94,14 @@
                         {{ html()->label('End Date', 'reservation-end-date') }}
                         {{ html()->text('end_date')->class('form-control flatpickr-date')->id('reservation-end-date') }}
                     </div>
+                    <div class="form-group">
+                        {{ html()->label('Guest', 'reservation-contact-id') }}
+                        {{ html()->select('contact_id', $retreatants)->class('form-control select2')->id('reservation-contact-id') }}
+                    </div>
+                    <div class="form-group">
+                        {{ html()->label('Retreat', 'reservation-event-id') }}
+                        {{ html()->select('event_id', $retreats)->class('form-control select2')->id('reservation-event-id') }}
+                    </div>
                 {{ html()->form()->close() }}
             </div>
             <div class="modal-footer">

--- a/tests/Feature/Http/Controllers/RoomControllerTest.php
+++ b/tests/Feature/Http/Controllers/RoomControllerTest.php
@@ -35,6 +35,8 @@ final class RoomControllerTest extends TestCase
     {
         $user = $this->createUserWithPermission('delete-room');
         $room = \App\Models\Room::factory()->create();
+        $contact = \App\Models\Contact::factory()->create();
+        $event = \App\Models\Retreat::factory()->create();
 
         $response = $this->actingAs($user)->delete(route('room.destroy', [$room]));
 
@@ -133,6 +135,8 @@ final class RoomControllerTest extends TestCase
         $response->assertViewHas('m');
         $response->assertViewHas('previous_link');
         $response->assertViewHas('next_link');
+        $response->assertViewHas('retreats');
+        $response->assertViewHas('retreatants');
         $response->assertSeeText('Room Schedules');
     }
 
@@ -182,8 +186,12 @@ final class RoomControllerTest extends TestCase
         $response = $this->actingAs($user)->get(route('rooms'));
 
         $response->assertOk();
+        $response->assertViewHas('retreats');
+        $response->assertViewHas('retreatants');
         $response->assertSee('id="reservationModal"', false);
         $response->assertSee('id="reservationForm"', false);
+        $response->assertSee('name="contact_id"', false);
+        $response->assertSee('name="event_id"', false);
     }
 
     #[Test]
@@ -302,12 +310,16 @@ final class RoomControllerTest extends TestCase
     {
         $user = $this->createUserWithPermission('create-registration');
         $room = \App\Models\Room::factory()->create();
+        $contact = \App\Models\Contact::factory()->create();
+        $event = \App\Models\Retreat::factory()->create();
 
         $start = now()->toDateString();
         $end = now()->addDay()->toDateString();
 
         $response = $this->actingAs($user)->post(route('rooms.create-reservation'), [
             'room_id' => $room->id,
+            'contact_id' => $contact->id,
+            'event_id' => $event->id,
             'start_date' => $start,
             'end_date' => $end,
         ]);


### PR DESCRIPTION
## Summary
- allow selecting guest and retreat when creating a room reservation
- handle reservation creation via AJAX
- expose guests and retreats to the room schedule view
- test updates

## Testing
- `composer install`
- `./vendor/bin/phpunit --filter RoomControllerTest --stop-on-failure` *(fails: Database file at path does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68742fbcc72883248dc1d5cad0869a63