### PR TITLE
Add reservations report

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -377,6 +377,29 @@ class PageController extends Controller
         return view('reports.retreatregistrations', compact('registrations'));   //
     }
 
+    public function reservations_report(Request $request)
+    {
+        $this->authorize('show-registration');
+
+        $reservations = \App\Models\Registration::whereNull('canceled_at')
+            ->where('room_id', '>', 0)
+            ->with('retreat', 'retreatant', 'room')
+            ->orderBy('register_date')
+            ->get();
+
+        if ($request->boolean('pdf')) {
+            $pdf = PDF::loadView('reports.reservations', compact('reservations'));
+            $pdf->setOptions([
+                'header-html' => view('pdf._header'),
+                'footer-html' => view('pdf._footer'),
+            ]);
+
+            return $pdf->inline('reservations.pdf');
+        }
+
+        return view('reports.reservations', compact('reservations'));   //
+    }
+
     public function eoy_acknowledgment($contact_id = null, $start_date = null, $end_date = null)
     {
         $this->authorize('show-donation');

--- a/resources/views/reports/reservations.blade.php
+++ b/resources/views/reports/reservations.blade.php
@@ -1,0 +1,24 @@
+@extends('report')
+@section('content')
+<h2>Reservations</h2>
+@if($reservations->isNotEmpty())
+<table width="100%">
+    <tr>
+        <th style="width:30%">Retreatant</th>
+        <th style="width:15%">Room</th>
+        <th style="width:30%">Retreat</th>
+        <th style="width:25%">Status</th>
+    </tr>
+    @foreach($reservations as $reservation)
+    <tr>
+        <td>{{ $reservation->retreatant->full_name }}</td>
+        <td>{{ $reservation->room_name }}</td>
+        <td>{{ $reservation->retreat_name }}</td>
+        <td>{{ $reservation->participant_status }}</td>
+    </tr>
+    @endforeach
+</table>
+@else
+<p>No reservations found.</p>
+@endif
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -310,6 +310,7 @@ Route::middleware('web', 'activity')->group(function () {
         Route::get('finance/cc_deposit/{day?}', [PageController::class, 'finance_cc_deposit'])->name('report.finance.cc_deposit');
         Route::get('finance/retreatdonations/{retreat_id?}', [PageController::class, 'finance_retreatdonations']);
         Route::get('finance/deposits', [PageController::class, 'finance_deposits']);
+        Route::get('reservations', [PageController::class, 'reservations_report'])->name('report.reservations');
     });
 
     Route::get('reservation', [PageController::class, 'reservation'])->name('reservation');

--- a/tests/Feature/Http/Controllers/PageControllerTest.php
+++ b/tests/Feature/Http/Controllers/PageControllerTest.php
@@ -669,6 +669,19 @@ final class PageControllerTest extends TestCase
     }
 
     #[Test]
+    public function reservations_report_returns_an_ok_response(): void
+    {
+        $user = $this->createUserWithPermission('show-registration');
+        \App\Models\Registration::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('report.reservations'));
+
+        $response->assertOk();
+        $response->assertViewIs('reports.reservations');
+        $response->assertViewHas('reservations');
+    }
+
+    #[Test]
     public function support_displays_view(): void
     {
         $user = \App\Models\User::factory()->create();


### PR DESCRIPTION
## Summary
- add reservations_report action to PageController
- create print-friendly reservations view
- expose report route
- test reservations report route

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: Errors 463)*

------
https://chatgpt.com/codex/tasks/task_e_687cb480d0388324b83e756cabec1650