### PR TITLE
Add reservation CRUD scaffolding

### DIFF
--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Reservation;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ReservationController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index(): JsonResponse
+    {
+        return response()->json(Reservation::all());
+    }
+
+    public function create(): JsonResponse
+    {
+        return response()->json(['status' => 'ok']);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $reservation = Reservation::create($request->all());
+
+        return redirect()->route('reservation.show', $reservation);
+    }
+
+    public function show(Reservation $reservation): JsonResponse
+    {
+        return response()->json($reservation);
+    }
+
+    public function edit(Reservation $reservation): JsonResponse
+    {
+        return response()->json($reservation);
+    }
+
+    public function update(Request $request, Reservation $reservation): RedirectResponse
+    {
+        $reservation->update($request->all());
+
+        return redirect()->route('reservation.show', $reservation);
+    }
+
+    public function destroy(Reservation $reservation): RedirectResponse
+    {
+        $reservation->delete();
+
+        return redirect()->route('reservation.index');
+    }
+}

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use OwenIt\Auditing\Contracts\Auditable;
+
+class Reservation extends Model implements Auditable
+{
+    use HasFactory;
+    use \OwenIt\Auditing\Auditable;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'room_id',
+        'registration_id',
+        'retreatant_id',
+        'retreat_id',
+        'group_id',
+        'start',
+        'end',
+        'notes',
+        'remember_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'start' => 'datetime',
+            'end' => 'datetime',
+        ];
+    }
+
+    public function room(): BelongsTo
+    {
+        return $this->belongsTo(Room::class, 'room_id', 'id');
+    }
+
+    public function registration(): BelongsTo
+    {
+        return $this->belongsTo(Registration::class, 'registration_id', 'id');
+    }
+
+    public function retreatant(): BelongsTo
+    {
+        return $this->belongsTo(Contact::class, 'retreatant_id', 'id');
+    }
+
+    public function retreat(): BelongsTo
+    {
+        return $this->belongsTo(Retreat::class, 'retreat_id', 'id');
+    }
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class, 'group_id', 'id');
+    }
+}

--- a/database/factories/ReservationFactory.php
+++ b/database/factories/ReservationFactory.php
@@ -13,7 +13,7 @@ class ReservationFactory extends Factory
      *
      * @var string
      */
-    protected $model = \App\Reservation::class;
+    protected $model = \App\Models\Reservation::class;
 
     /**
      * Define the model's default state.

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ use App\Http\Controllers\RetreatController;
 use App\Http\Controllers\RoleController;
 use App\Http\Controllers\RoomController;
 use App\Http\Controllers\RoomstateController;
+use App\Http\Controllers\ReservationController;
 use App\Http\Controllers\SearchController;
 use App\Http\Controllers\SnippetController;
 use App\Http\Controllers\SquarespaceContributionController;
@@ -312,7 +313,7 @@ Route::middleware('web', 'activity')->group(function () {
         Route::get('finance/deposits', [PageController::class, 'finance_deposits']);
     });
 
-    Route::get('reservation', [PageController::class, 'reservation'])->name('reservation');
+    Route::resource('reservation', ReservationController::class);
     Route::get('restricted', [PageController::class, 'restricted'])->name('restricted');
 
     Route::get('retreat/{event_id}/attachment/{file_name}', [AttachmentController::class, 'show_event_attachment'])->name('show_event_attachment');

--- a/tests/Feature/Http/Controllers/ReservationControllerTest.php
+++ b/tests/Feature/Http/Controllers/ReservationControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Reservation;
+use App\Models\Registration;
+use App\Models\Room;
+use App\Models\User;
+use Illuminate\Foundation\Testing\WithFaker;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ReservationControllerTest extends TestCase
+{
+    use WithFaker;
+
+    #[Test]
+    public function index_returns_an_ok_response(): void
+    {
+        $user = User::factory()->create();
+        $reservation = Reservation::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('reservation.index'));
+
+        $response->assertOk();
+        $response->assertJsonFragment(['id' => $reservation->id]);
+    }
+
+    #[Test]
+    public function store_creates_a_new_reservation(): void
+    {
+        $user = User::factory()->create();
+        $room = Room::factory()->create();
+        $registration = Registration::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('reservation.store'), [
+            'room_id' => $room->id,
+            'registration_id' => $registration->id,
+            'start' => now()->toDateTimeString(),
+            'end' => now()->addHour()->toDateTimeString(),
+            'notes' => 'test notes',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('reservations', [
+            'room_id' => $room->id,
+            'registration_id' => $registration->id,
+            'notes' => 'test notes',
+        ]);
+    }
+
+    #[Test]
+    public function edit_returns_an_ok_response(): void
+    {
+        $user = User::factory()->create();
+        $reservation = Reservation::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('reservation.edit', $reservation));
+
+        $response->assertOk();
+        $response->assertJsonFragment(['id' => $reservation->id]);
+    }
+
+    #[Test]
+    public function destroy_deletes_reservation(): void
+    {
+        $user = User::factory()->create();
+        $reservation = Reservation::factory()->create();
+
+        $response = $this->actingAs($user)->delete(route('reservation.destroy', $reservation));
+
+        $response->assertRedirect(route('reservation.index'));
+        $this->assertSoftDeleted($reservation);
+    }
+}


### PR DESCRIPTION
## Summary
- create `Reservation` model
- add factory model reference
- implement `ReservationController`
- register reservation routes
- add feature tests for reservation CRUD endpoints

## Testing
- `vendor/bin/phpunit --filter=ReservationControllerTest --testsuite Feature` *(fails: Database file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687cb47fdc6083249b3de5271c0b53e4