### PR TITLE
Handle non-AJAX room reservation requests

### DIFF
--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -410,6 +410,12 @@ class RoomController extends Controller
             }
         }
 
-        return response()->json(['status' => 'ok', 'registration_id' => $registration->id]);
+        if ($request->ajax() || $request->wantsJson()) {
+            return response()->json(['status' => 'ok', 'registration_id' => $registration->id]);
+        }
+
+        flash('Reservation created')->success();
+
+        return redirect()->route('rooms', Carbon::parse($data['start_date'])->format('Y-m-d'));
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,7 +36,6 @@ use App\Http\Controllers\RetreatController;
 use App\Http\Controllers\RoleController;
 use App\Http\Controllers\RoomController;
 use App\Http\Controllers\RoomstateController;
-use App\Http\Controllers\ReservationController;
 use App\Http\Controllers\SearchController;
 use App\Http\Controllers\SnippetController;
 use App\Http\Controllers\SquarespaceContributionController;

--- a/tests/Feature/Http/Controllers/RoomControllerTest.php
+++ b/tests/Feature/Http/Controllers/RoomControllerTest.php
@@ -317,7 +317,7 @@ final class RoomControllerTest extends TestCase
         $start = now()->toDateString();
         $end = now()->addDay()->toDateString();
 
-        $response = $this->actingAs($user)->post(route('rooms.create-reservation'), [
+        $response = $this->actingAs($user)->postJson(route('rooms.create-reservation'), [
             'room_id' => $room->id,
             'contact_id' => $contact->id,
             'event_id' => $event->id,
@@ -349,7 +349,7 @@ final class RoomControllerTest extends TestCase
         $start = now()->toDateString();
         $end = now()->addDay()->toDateString();
 
-        $this->actingAs($user)->post(route('rooms.create-reservation'), [
+        $this->actingAs($user)->postJson(route('rooms.create-reservation'), [
             'room_id' => $room->id,
             'contact_id' => $contact->id,
             'event_id' => $event->id,


### PR DESCRIPTION
## Summary
- return redirect+flash when reservation creation isn't AJAX
- keep JSON response for AJAX requests
- update tests to post JSON when creating reservations
- remove duplicate `ReservationController` import to allow tests to run

## Testing
- `vendor/bin/phpunit --stop-on-failure` *(fails: Database file at path /workspace/montserrat-master/database/database.sqlite does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687d61920b0483249880335195f47969