### PR TITLE
Fix retreat filtering in schedule

### DIFF
--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -217,8 +217,9 @@ class RoomController extends Controller
         });
 
         $retreats = \App\Models\Retreat::select(DB::raw('CONCAT(idnumber, "-", title, " (",DATE_FORMAT(start_date,"%m-%d-%Y"),")") as description'), 'id')
-            ->where('end_date', '>', Carbon::today()->subWeek())
-            ->where('is_active', '=', 1)
+            ->whereBetween('start_date', [$dts[0], $dts[31]])
+            ->where('end_date', '>=', Carbon::today())
+            ->where('is_active', 1)
             ->orderBy('start_date')
             ->pluck('description', 'id');
         $retreats->prepend('Unassigned', 0);

--- a/tests/Feature/Http/Controllers/RoomControllerTest.php
+++ b/tests/Feature/Http/Controllers/RoomControllerTest.php
@@ -396,5 +396,30 @@ final class RoomControllerTest extends TestCase
 
     }
 
+    #[Test]
+    public function schedule_filters_retreats_by_end_date(): void
+    {
+        Carbon::setTestNow(Carbon::create(2025, 7, 15));
+        $user = $this->createUserWithPermission('show-room');
+
+        $past = \App\Models\Retreat::factory()->create([
+            'start_date' => Carbon::create(2025, 7, 1),
+            'end_date' => Carbon::create(2025, 7, 5),
+        ]);
+        $future = \App\Models\Retreat::factory()->create([
+            'start_date' => Carbon::create(2025, 7, 20),
+            'end_date' => Carbon::create(2025, 7, 22),
+        ]);
+
+        $response = $this->actingAs($user)->get(route('rooms', ['ymd' => '2025-07-01']));
+
+        $response->assertOk();
+        $retreats = $response->viewData('retreats');
+        $this->assertTrue($retreats->has($future->id));
+        $this->assertFalse($retreats->has($past->id));
+
+        Carbon::setTestNow();
+    }
+
     // test cases...
 }


### PR DESCRIPTION
## Summary
- filter schedule retreat dropdown so only active retreats within date range appear
- test the retreat filtering logic

## Testing
- `vendor/bin/phpunit --testdox` *(fails: SQLSTATE[HY000] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687e8e76322483249ed6aa6f3d62ca3c