### PR TITLE
Add Meal management

### DIFF
--- a/app/Http/Controllers/MealController.php
+++ b/app/Http/Controllers/MealController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreMealRequest;
+use App\Http\Requests\UpdateMealRequest;
+use App\Models\Meal;
+use App\Models\Retreat;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\View\View;
+
+class MealController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index(): View
+    {
+        $this->authorize('show-meal');
+        $meals = Meal::with('retreat')->orderBy('meal_date')->get();
+
+        return view('meals.index', compact('meals'));   //
+    }
+
+    public function create(): View
+    {
+        $this->authorize('create-meal');
+        $retreats = Retreat::orderBy('start_date')->pluck('title', 'id');
+
+        return view('meals.create', compact('retreats'));   //
+    }
+
+    public function store(StoreMealRequest $request): RedirectResponse
+    {
+        $this->authorize('create-meal');
+        $meal = Meal::create($request->validated());
+
+        flash('Meal added')->success();
+
+        return Redirect::action([self::class, 'index']);
+    }
+
+    public function show(int $id): View
+    {
+        $this->authorize('show-meal');
+        $meal = Meal::with('retreat')->findOrFail($id);
+
+        return view('meals.show', compact('meal'));   //
+    }
+
+    public function edit(int $id): View
+    {
+        $this->authorize('update-meal');
+        $meal = Meal::findOrFail($id);
+        $retreats = Retreat::orderBy('start_date')->pluck('title', 'id');
+
+        return view('meals.edit', compact('meal', 'retreats'));   //
+    }
+
+    public function update(UpdateMealRequest $request, int $id): RedirectResponse
+    {
+        $this->authorize('update-meal');
+        $meal = Meal::findOrFail($id);
+        $meal->update($request->validated());
+
+        flash('Meal updated')->success();
+
+        return Redirect::action([self::class, 'show'], $meal->id);
+    }
+
+    public function destroy(int $id): RedirectResponse
+    {
+        $this->authorize('delete-meal');
+        $meal = Meal::findOrFail($id);
+        Meal::destroy($id);
+
+        flash('Meal deleted')->warning()->important();
+
+        return Redirect::action([self::class, 'index']);
+    }
+
+    public function report(int $retreat_id): View
+    {
+        $this->authorize('show-meal');
+        $retreat = Retreat::findOrFail($retreat_id);
+        $meals = Meal::where('retreat_id', $retreat_id)->orderBy('meal_date')->get();
+
+        return view('meals.report', compact('retreat', 'meals'));   //
+    }
+}

--- a/app/Http/Requests/StoreMealRequest.php
+++ b/app/Http/Requests/StoreMealRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreMealRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'retreat_id' => 'integer|exists:event,id|required',
+            'meal_date' => 'date|required',
+            'meal_type' => 'string|required',
+            'vegetarian_count' => 'integer|nullable',
+            'gluten_free_count' => 'integer|nullable',
+            'dairy_free_count' => 'integer|nullable',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/UpdateMealRequest.php
+++ b/app/Http/Requests/UpdateMealRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateMealRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'id' => 'integer|min:1|required',
+            'retreat_id' => 'integer|exists:event,id|required',
+            'meal_date' => 'date|required',
+            'meal_type' => 'string|required',
+            'vegetarian_count' => 'integer|nullable',
+            'gluten_free_count' => 'integer|nullable',
+            'dairy_free_count' => 'integer|nullable',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/Meal.php
+++ b/app/Models/Meal.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Meal extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'retreat_id',
+        'meal_date',
+        'meal_type',
+        'vegetarian_count',
+        'gluten_free_count',
+        'dairy_free_count',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'meal_date' => 'datetime',
+        ];
+    }
+
+    public function retreat(): BelongsTo
+    {
+        return $this->belongsTo(Retreat::class);
+    }
+}

--- a/database/factories/MealFactory.php
+++ b/database/factories/MealFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MealFactory extends Factory
+{
+    protected $model = \App\Models\Meal::class;
+
+    public function definition(): array
+    {
+        return [
+            'retreat_id' => \App\Models\Retreat::factory(),
+            'meal_date' => $this->faker->dateTimeBetween('-1 week', '+1 week'),
+            'meal_type' => $this->faker->randomElement(['Breakfast', 'Lunch', 'Dinner']),
+            'vegetarian_count' => $this->faker->numberBetween(0, 10),
+            'gluten_free_count' => $this->faker->numberBetween(0, 10),
+            'dairy_free_count' => $this->faker->numberBetween(0, 10),
+        ];
+    }
+}

--- a/database/migrations/2024_11_04_000000_create_meals_table.php
+++ b/database/migrations/2024_11_04_000000_create_meals_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('meals', function (Blueprint $table) {
+            $table->id();
+            $table->integer('retreat_id')->index('idx_retreat_id');
+            $table->date('meal_date');
+            $table->string('meal_type');
+            $table->integer('vegetarian_count')->default(0);
+            $table->integer('gluten_free_count')->default(0);
+            $table->integer('dairy_free_count')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('meals');
+    }
+};

--- a/resources/views/meals/create.blade.php
+++ b/resources/views/meals/create.blade.php
@@ -1,0 +1,47 @@
+@extends('template')
+@section('content')
+<div class="row bg-cover">
+    <div class="col-lg-12">
+        <h1>Create meal</h1>
+    </div>
+    <div class="col-lg-12">
+        {{ html()->form('POST', route('meal.store'))->open() }}
+            <div class="form-group">
+                <div class="row">
+                    <div class="col-lg-4">
+                        {{ html()->label('Retreat', 'retreat_id') }}
+                        {{ html()->select('retreat_id')->options($retreats)->class('form-control') }}
+                    </div>
+                    <div class="col-lg-4">
+                        {{ html()->label('Date', 'meal_date') }}
+                        {{ html()->date('meal_date')->class('form-control') }}
+                    </div>
+                    <div class="col-lg-4">
+                        {{ html()->label('Type', 'meal_type') }}
+                        {{ html()->text('meal_type')->class('form-control') }}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-4">
+                        {{ html()->label('Vegetarian', 'vegetarian_count') }}
+                        {{ html()->number('vegetarian_count')->class('form-control')->value(0) }}
+                    </div>
+                    <div class="col-lg-4">
+                        {{ html()->label('Gluten Free', 'gluten_free_count') }}
+                        {{ html()->number('gluten_free_count')->class('form-control')->value(0) }}
+                    </div>
+                    <div class="col-lg-4">
+                        {{ html()->label('Dairy Free', 'dairy_free_count') }}
+                        {{ html()->number('dairy_free_count')->class('form-control')->value(0) }}
+                    </div>
+                </div>
+            </div>
+            <div class="row text-center">
+                <div class="col-lg-12">
+                    {{ html()->submit('Add meal')->class('btn btn-outline-dark') }}
+                </div>
+            </div>
+        {{ html()->form()->close() }}
+    </div>
+</div>
+@stop

--- a/resources/views/meals/edit.blade.php
+++ b/resources/views/meals/edit.blade.php
@@ -1,0 +1,48 @@
+@extends('template')
+@section('content')
+<div class="row bg-cover">
+    <div class="col-lg-12">
+        <h1>Edit meal</h1>
+    </div>
+    <div class="col-lg-12">
+        {{ html()->form('PUT', route('meal.update', $meal))->open() }}
+            {{ html()->hidden('id')->value($meal->id) }}
+            <div class="form-group">
+                <div class="row">
+                    <div class="col-lg-4">
+                        {{ html()->label('Retreat', 'retreat_id') }}
+                        {{ html()->select('retreat_id')->options($retreats)->value($meal->retreat_id)->class('form-control') }}
+                    </div>
+                    <div class="col-lg-4">
+                        {{ html()->label('Date', 'meal_date') }}
+                        {{ html()->date('meal_date', $meal->meal_date)->class('form-control') }}
+                    </div>
+                    <div class="col-lg-4">
+                        {{ html()->label('Type', 'meal_type') }}
+                        {{ html()->text('meal_type')->value($meal->meal_type)->class('form-control') }}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-4">
+                        {{ html()->label('Vegetarian', 'vegetarian_count') }}
+                        {{ html()->number('vegetarian_count')->value($meal->vegetarian_count)->class('form-control') }}
+                    </div>
+                    <div class="col-lg-4">
+                        {{ html()->label('Gluten Free', 'gluten_free_count') }}
+                        {{ html()->number('gluten_free_count')->value($meal->gluten_free_count)->class('form-control') }}
+                    </div>
+                    <div class="col-lg-4">
+                        {{ html()->label('Dairy Free', 'dairy_free_count') }}
+                        {{ html()->number('dairy_free_count')->value($meal->dairy_free_count)->class('form-control') }}
+                    </div>
+                </div>
+            </div>
+            <div class="row text-center">
+                <div class="col-lg-12">
+                    {{ html()->submit('Update meal')->class('btn btn-outline-dark') }}
+                </div>
+            </div>
+        {{ html()->form()->close() }}
+    </div>
+</div>
+@stop

--- a/resources/views/meals/index.blade.php
+++ b/resources/views/meals/index.blade.php
@@ -1,0 +1,49 @@
+@extends('template')
+@section('content')
+<div class="row bg-cover">
+    <div class="col-lg-12">
+        <h2>
+            Meals
+            @can('create-meal')
+                <span class="options">
+                    <a href="{{ route('meal.create') }}">
+                        <img src="{{ URL::asset('images/create.png') }}" alt="Add" class="btn btn-light" title="Add">
+                    </a>
+                </span>
+            @endcan
+        </h2>
+    </div>
+    <div class="col-lg-12 my-3 table-responsive-md">
+        @if ($meals->isEmpty())
+            <div class="col-lg-12 text-center py-5">
+                <p>No meals found.</p>
+            </div>
+        @else
+            <table class="table table-striped table-bordered table-hover">
+                <thead>
+                    <tr>
+                        <th scope="col">Retreat</th>
+                        <th scope="col">Date</th>
+                        <th scope="col">Type</th>
+                        <th scope="col">Vegetarian</th>
+                        <th scope="col">Gluten Free</th>
+                        <th scope="col">Dairy Free</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($meals as $meal)
+                    <tr>
+                        <td><a href="{{ route('meal.show', $meal) }}">{{ $meal->retreat->title ?? '' }}</a></td>
+                        <td>{{ $meal->meal_date->format('Y-m-d') }}</td>
+                        <td>{{ $meal->meal_type }}</td>
+                        <td>{{ $meal->vegetarian_count }}</td>
+                        <td>{{ $meal->gluten_free_count }}</td>
+                        <td>{{ $meal->dairy_free_count }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        @endif
+    </div>
+</div>
+@stop

--- a/resources/views/meals/report.blade.php
+++ b/resources/views/meals/report.blade.php
@@ -1,0 +1,38 @@
+@extends('template')
+@section('content')
+<div class="row bg-cover">
+    <div class="col-lg-12">
+        <h2>Meals for {{ $retreat->title }}</h2>
+    </div>
+    <div class="col-lg-12 my-3 table-responsive-md">
+        @if ($meals->isEmpty())
+            <div class="col-lg-12 text-center py-5">
+                <p>No meals recorded.</p>
+            </div>
+        @else
+            <table class="table table-striped table-bordered table-hover">
+                <thead>
+                    <tr>
+                        <th scope="col">Date</th>
+                        <th scope="col">Type</th>
+                        <th scope="col">Vegetarian</th>
+                        <th scope="col">Gluten Free</th>
+                        <th scope="col">Dairy Free</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($meals as $meal)
+                    <tr>
+                        <td>{{ $meal->meal_date->format('Y-m-d') }}</td>
+                        <td>{{ $meal->meal_type }}</td>
+                        <td>{{ $meal->vegetarian_count }}</td>
+                        <td>{{ $meal->gluten_free_count }}</td>
+                        <td>{{ $meal->dairy_free_count }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        @endif
+    </div>
+</div>
+@stop

--- a/resources/views/meals/show.blade.php
+++ b/resources/views/meals/show.blade.php
@@ -1,0 +1,36 @@
+@extends('template')
+@section('content')
+<div class="row bg-cover">
+    <div class="col-lg-12">
+        <h2>Meal details</h2>
+    </div>
+    <div class="col-lg-12 my-3">
+        <table class="table table-bordered">
+            <tr>
+                <th>Retreat</th>
+                <td>{{ $meal->retreat->title ?? '' }}</td>
+            </tr>
+            <tr>
+                <th>Date</th>
+                <td>{{ $meal->meal_date->format('Y-m-d') }}</td>
+            </tr>
+            <tr>
+                <th>Type</th>
+                <td>{{ $meal->meal_type }}</td>
+            </tr>
+            <tr>
+                <th>Vegetarian</th>
+                <td>{{ $meal->vegetarian_count }}</td>
+            </tr>
+            <tr>
+                <th>Gluten Free</th>
+                <td>{{ $meal->gluten_free_count }}</td>
+            </tr>
+            <tr>
+                <th>Dairy Free</th>
+                <td>{{ $meal->dairy_free_count }}</td>
+            </tr>
+        </table>
+    </div>
+</div>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,7 @@ use App\Http\Controllers\RetreatController;
 use App\Http\Controllers\RoleController;
 use App\Http\Controllers\RoomController;
 use App\Http\Controllers\RoomstateController;
+use App\Http\Controllers\MealController;
 use App\Http\Controllers\SearchController;
 use App\Http\Controllers\SnippetController;
 use App\Http\Controllers\SquarespaceContributionController;
@@ -361,6 +362,9 @@ Route::middleware('web', 'activity')->group(function () {
     Route::post('rooms/create-reservation', [RoomController::class, 'createReservation'])->name('rooms.create-reservation');
 
     Route::resource('roomstate', RoomstateController::class)->only(['index', 'store', 'update']);
+
+    Route::resource('meal', MealController::class);
+    Route::get('report/meal/{retreat}', [MealController::class, 'report'])->name('report.meal');
 
     Route::name('squarespace.')->prefix('squarespace')->group(function () {
         Route::resource('/', SquarespaceController::class);

--- a/tests/Feature/Http/Controllers/MealControllerTest.php
+++ b/tests/Feature/Http/Controllers/MealControllerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Meal;
+use App\Models\Retreat;
+use PHPUnit\Framework\Attributes\Test;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+final class MealControllerTest extends TestCase
+{
+    use WithFaker;
+
+    #[Test]
+    public function index_returns_an_ok_response(): void
+    {
+        $user = $this->createUserWithPermission('show-meal');
+        $meal = Meal::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('meal.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('meals.index');
+        $response->assertViewHas('meals');
+        $response->assertSeeText('Meals');
+    }
+
+    #[Test]
+    public function create_returns_an_ok_response(): void
+    {
+        $user = $this->createUserWithPermission('create-meal');
+
+        $response = $this->actingAs($user)->get(route('meal.create'));
+
+        $response->assertOk();
+        $response->assertViewIs('meals.create');
+        $response->assertViewHas('retreats');
+        $response->assertSeeText('Create meal');
+    }
+
+    #[Test]
+    public function store_returns_an_ok_response(): void
+    {
+        $user = $this->createUserWithPermission('create-meal');
+        $retreat = Retreat::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('meal.store'), [
+            'retreat_id' => $retreat->id,
+            'meal_date' => now()->format('Y-m-d'),
+            'meal_type' => 'Lunch',
+            'vegetarian_count' => 1,
+            'gluten_free_count' => 2,
+            'dairy_free_count' => 3,
+        ]);
+
+        $response->assertRedirect(action([\App\Http\Controllers\MealController::class, 'index']));
+        $response->assertSessionHas('flash_notification');
+
+        $this->assertDatabaseHas('meals', [
+            'retreat_id' => $retreat->id,
+            'meal_type' => 'Lunch',
+        ]);
+    }
+
+    #[Test]
+    public function show_returns_an_ok_response(): void
+    {
+        $user = $this->createUserWithPermission('show-meal');
+        $meal = Meal::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('meal.show', [$meal]));
+
+        $response->assertOk();
+        $response->assertViewIs('meals.show');
+        $response->assertViewHas('meal');
+        $response->assertSeeText('Meal details');
+    }
+
+    #[Test]
+    public function edit_returns_an_ok_response(): void
+    {
+        $user = $this->createUserWithPermission('update-meal');
+        $meal = Meal::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('meal.edit', [$meal]));
+
+        $response->assertOk();
+        $response->assertViewIs('meals.edit');
+        $response->assertViewHas('meal');
+        $response->assertViewHas('retreats');
+        $response->assertSeeText('Edit meal');
+    }
+
+    #[Test]
+    public function update_returns_an_ok_response(): void
+    {
+        $user = $this->createUserWithPermission('update-meal');
+        $meal = Meal::factory()->create();
+
+        $response = $this->actingAs($user)->put(route('meal.update', [$meal]), [
+            'id' => $meal->id,
+            'retreat_id' => $meal->retreat_id,
+            'meal_date' => now()->format('Y-m-d'),
+            'meal_type' => 'Dinner',
+            'vegetarian_count' => 2,
+            'gluten_free_count' => 0,
+            'dairy_free_count' => 0,
+        ]);
+
+        $response->assertRedirect(action([\App\Http\Controllers\MealController::class, 'show'], $meal->id));
+        $response->assertSessionHas('flash_notification');
+
+        $this->assertDatabaseHas('meals', [
+            'id' => $meal->id,
+            'meal_type' => 'Dinner',
+        ]);
+    }
+
+    #[Test]
+    public function destroy_returns_an_ok_response(): void
+    {
+        $user = $this->createUserWithPermission('delete-meal');
+        $meal = Meal::factory()->create();
+
+        $response = $this->actingAs($user)->delete(route('meal.destroy', [$meal]));
+
+        $response->assertSessionHas('flash_notification');
+        $response->assertRedirect(action([\App\Http\Controllers\MealController::class, 'index']));
+        $this->assertSoftDeleted($meal);
+    }
+
+    #[Test]
+    public function report_returns_an_ok_response(): void
+    {
+        $user = $this->createUserWithPermission('show-meal');
+        $meal = Meal::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('report.meal', $meal->retreat_id));
+
+        $response->assertOk();
+        $response->assertViewIs('meals.report');
+        $response->assertViewHas('retreat');
+        $response->assertViewHas('meals');
+    }
+}

--- a/tests/Unit/Http/Requests/StoreMealRequestTest.php
+++ b/tests/Unit/Http/Requests/StoreMealRequestTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Http\Requests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class StoreMealRequestTest extends TestCase
+{
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new \App\Http\Requests\StoreMealRequest;
+    }
+
+    #[Test]
+    public function authorize(): void
+    {
+        $actual = $this->subject->authorize();
+        $this->assertTrue($actual);
+    }
+
+    #[Test]
+    public function rules(): void
+    {
+        $actual = $this->subject->rules();
+
+        $this->assertEquals([
+            'retreat_id' => 'integer|exists:event,id|required',
+            'meal_date' => 'date|required',
+            'meal_type' => 'string|required',
+            'vegetarian_count' => 'integer|nullable',
+            'gluten_free_count' => 'integer|nullable',
+            'dairy_free_count' => 'integer|nullable',
+        ], $actual);
+    }
+
+    #[Test]
+    public function messages(): void
+    {
+        $actual = $this->subject->messages();
+
+        $this->assertEquals([], $actual);
+    }
+}

--- a/tests/Unit/Http/Requests/UpdateMealRequestTest.php
+++ b/tests/Unit/Http/Requests/UpdateMealRequestTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Http\Requests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class UpdateMealRequestTest extends TestCase
+{
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new \App\Http\Requests\UpdateMealRequest;
+    }
+
+    #[Test]
+    public function authorize(): void
+    {
+        $actual = $this->subject->authorize();
+        $this->assertTrue($actual);
+    }
+
+    #[Test]
+    public function rules(): void
+    {
+        $actual = $this->subject->rules();
+
+        $this->assertEquals([
+            'id' => 'integer|min:1|required',
+            'retreat_id' => 'integer|exists:event,id|required',
+            'meal_date' => 'date|required',
+            'meal_type' => 'string|required',
+            'vegetarian_count' => 'integer|nullable',
+            'gluten_free_count' => 'integer|nullable',
+            'dairy_free_count' => 'integer|nullable',
+        ], $actual);
+    }
+
+    #[Test]
+    public function messages(): void
+    {
+        $actual = $this->subject->messages();
+
+        $this->assertEquals([], $actual);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Meal` model with relation to retreats
- migration for `meals` table
- implement `MealController` CRUD and report
- define routes and stub blade views
- create factory and request validation
- add feature and unit tests

## Testing
- `composer install`
- `vendor/bin/phpunit --testsuite Unit --stop-on-failure` *(fails: Database file at path does not exist)*
- `vendor/bin/phpunit --testsuite Feature --stop-on-failure` *(fails: many errors)*

------
https://chatgpt.com/codex/tasks/task_e_687eb3f2ecc883248c8c42a01790022e