### PR TITLE
Add meal requests and validation tests

### DIFF
--- a/app/Http/Controllers/MealController.php
+++ b/app/Http/Controllers/MealController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreMealRequest;
+use App\Http\Requests\UpdateMealRequest;
+use App\Models\Meal;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Redirect;
+
+class MealController extends Controller
+{
+    public function store(StoreMealRequest $request): RedirectResponse
+    {
+        $meal = Meal::create($request->validated());
+
+        return Redirect::action([self::class, 'show'], $meal->id);
+    }
+
+    public function update(UpdateMealRequest $request, Meal $meal): RedirectResponse
+    {
+        $meal->update($request->validated());
+
+        return Redirect::action([self::class, 'show'], $meal->id);
+    }
+
+    // Dummy show method for redirects
+    public function show(Meal $meal)
+    {
+        return view('meals.show', compact('meal'));
+    }
+}

--- a/app/Http/Requests/StoreMealRequest.php
+++ b/app/Http/Requests/StoreMealRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreMealRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'description' => 'string|nullable',
+            'price' => 'required|numeric|min:0',
+            'calories' => 'integer|nullable|min:0',
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     */
+    public function messages(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/UpdateMealRequest.php
+++ b/app/Http/Requests/UpdateMealRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateMealRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'description' => 'string|nullable',
+            'price' => 'required|numeric|min:0',
+            'calories' => 'integer|nullable|min:0',
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     */
+    public function messages(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/Meal.php
+++ b/app/Models/Meal.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Meal extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'description', 'price', 'calories'];
+}

--- a/tests/Feature/Http/Controllers/MealControllerTest.php
+++ b/tests/Feature/Http/Controllers/MealControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\MealController
+ */
+final class MealControllerTest extends TestCase
+{
+    #[Test]
+    public function store_uses_form_request(): void
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\MealController::class,
+            'store',
+            \App\Http\Requests\StoreMealRequest::class
+        );
+    }
+
+    #[Test]
+    public function update_uses_form_request(): void
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\MealController::class,
+            'update',
+            \App\Http\Requests\UpdateMealRequest::class
+        );
+    }
+}

--- a/tests/Unit/Http/Requests/StoreMealRequestTest.php
+++ b/tests/Unit/Http/Requests/StoreMealRequestTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit\Http\Requests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Requests\StoreMealRequest
+ */
+final class StoreMealRequestTest extends TestCase
+{
+    /** @var \App\Http\Requests\StoreMealRequest */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new \App\Http\Requests\StoreMealRequest();
+    }
+
+    #[Test]
+    public function authorize(): void
+    {
+        $this->assertTrue($this->subject->authorize());
+    }
+
+    #[Test]
+    public function rules(): void
+    {
+        $this->assertEquals([
+            'name' => 'required|string|max:255',
+            'description' => 'string|nullable',
+            'price' => 'required|numeric|min:0',
+            'calories' => 'integer|nullable|min:0',
+        ], $this->subject->rules());
+    }
+
+    #[Test]
+    public function messages(): void
+    {
+        $this->assertEquals([], $this->subject->messages());
+    }
+}

--- a/tests/Unit/Http/Requests/UpdateMealRequestTest.php
+++ b/tests/Unit/Http/Requests/UpdateMealRequestTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit\Http\Requests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Requests\UpdateMealRequest
+ */
+final class UpdateMealRequestTest extends TestCase
+{
+    /** @var \App\Http\Requests\UpdateMealRequest */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new \App\Http\Requests\UpdateMealRequest();
+    }
+
+    #[Test]
+    public function authorize(): void
+    {
+        $this->assertTrue($this->subject->authorize());
+    }
+
+    #[Test]
+    public function rules(): void
+    {
+        $this->assertEquals([
+            'name' => 'required|string|max:255',
+            'description' => 'string|nullable',
+            'price' => 'required|numeric|min:0',
+            'calories' => 'integer|nullable|min:0',
+        ], $this->subject->rules());
+    }
+
+    #[Test]
+    public function messages(): void
+    {
+        $this->assertEquals([], $this->subject->messages());
+    }
+}


### PR DESCRIPTION
## Summary
- add `StoreMealRequest` and `UpdateMealRequest`
- add simple `MealController` using those requests
- add unit tests for new requests
- add controller test ensuring form requests are used

## Testing
- `vendor/bin/phpunit --testsuite Unit --filter StoreMealRequestTest`
- `vendor/bin/phpunit --testsuite Unit --filter UpdateMealRequestTest`
- `vendor/bin/phpunit --testsuite Feature --filter MealControllerTest`
- `vendor/bin/phpunit --testsuite Unit` *(fails: RoomstateFactoryTest)*

------
https://chatgpt.com/codex/tasks/task_e_687eb3f3198c8324a2f3531b775d3bd6