### PR TITLE
Implement meal summary report

### DIFF
--- a/resources/views/reports/meal_summary.blade.php
+++ b/resources/views/reports/meal_summary.blade.php
@@ -1,0 +1,37 @@
+@extends('report')
+@section('content')
+<div class="meal-summary">
+    <h2>Meal Summary for Retreat #{{ $retreat->idnumber }} - {{ $retreat->title }}</h2>
+    <table width="100%">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Breakfast</th>
+                <th>Lunch</th>
+                <th>Snack</th>
+                <th>Dinner</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($days as $day => $meals)
+            <tr>
+                <td>{{ \Carbon\Carbon::parse($day)->format('F j, Y') }}</td>
+                <td align="center">{{ $meals['Breakfast'] }}</td>
+                <td align="center">{{ $meals['Lunch'] }}</td>
+                <td align="center">{{ $meals['Snack'] }}</td>
+                <td align="center">{{ $meals['Dinner'] }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    @if(!empty($dietary))
+    <h3>Dietary Preferences</h3>
+    <ul>
+        @foreach($dietary as $pref => $count)
+        <li>{{ $pref }} - {{ $count }}</li>
+        @endforeach
+    </ul>
+    @endif
+</div>
+@endsection

--- a/resources/views/retreats/show.blade.php
+++ b/resources/views/retreats/show.blade.php
@@ -26,6 +26,7 @@
                 <option value="{{url('report/retreatantinfo/'.$retreat->idnumber)}}">Retreatant info sheets</option>
                 <option value="{{url('retreat/'.$retreat->id.'/roomlist')}}">Room list</option>
                 <option value="{{url('retreat/'.$retreat->id.'/tableplacards')}}">Table placards</option>
+                <option value="{{url('report/meal_summary/'.$retreat->idnumber)}}">Meal Summary</option>
                 <option value="{{url('report/retreatregistrations/'.$retreat->idnumber)}}">Registrations</option>
                 @can('show-donation')
                     <option value="{{url('report/finance/retreatdonations/'.$retreat->idnumber)}}">Donations</option>

--- a/routes/web.php
+++ b/routes/web.php
@@ -307,6 +307,7 @@ Route::middleware('web', 'activity')->group(function () {
         Route::get('retreatregistrations/{retreat_id}', [PageController::class, 'retreatregistrations']);
         Route::get('retreatroster/{retreat_id}', [PageController::class, 'retreatrosterreport']);
         Route::get('retreatrosterphone/{retreat_id}', [PageController::class, 'retreatrosterphonereport']);
+        Route::get('meal_summary/{retreat_id}', [PageController::class, 'retreatmealcounts'])->name('report.meal_summary');
         Route::get('contact_info_report/{id}', [PageController::class, 'contact_info_report']);
         Route::get('finance/cash_deposit/{day?}', [PageController::class, 'finance_cash_deposit'])->name('report.finance.cash_deposit');
         Route::get('finance/cc_deposit/{day?}', [PageController::class, 'finance_cc_deposit'])->name('report.finance.cc_deposit');


### PR DESCRIPTION
## Summary
- aggregate meal counts and dietary notes for a retreat
- render a meal summary report
- link meal summary report from retreat dashboard

## Testing
- `./vendor/bin/phpunit --dont-report-useless-tests` *(fails: Database file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687eb3f40d508324af28c41c5940bc4f