### PR TITLE
Fix room relation and add housekeeping tests

### DIFF
--- a/app/Http/Controllers/RetreatController.php
+++ b/app/Http/Controllers/RetreatController.php
@@ -585,6 +585,20 @@ class RetreatController extends Controller
         // TODO: consider also checking to see if the arrived_at time is empty and if it is put in the retreat start time
         $this->authorize('update-registration');
         $retreat = \App\Models\Retreat::findOrFail($id); //verifies that it is a valid retreat id
+        $registrations = \App\Models\Registration::whereEventId($id)
+            ->whereCanceledAt(null)
+            ->whereNotNull('arrived_at')
+            ->whereNull('departed_at')
+            ->get();
+
+        foreach ($registrations as $registration) {
+            $registration->departed_at = $registration->retreat_end_date ?? now();
+            $registration->save();
+        }
+
+        flash('Retreatants for '.$retreat->title.' successfully checked out')->success();
+
+        return Redirect::action([self::class, 'show'], $retreat->id);
     }
 
     public function checkin($id): RedirectResponse

--- a/app/Http/Requests/UpdateRoomRequest.php
+++ b/app/Http/Requests/UpdateRoomRequest.php
@@ -38,8 +38,5 @@ class UpdateRoomRequest extends FormRequest
     public function messages(): array
     {
         return [];
-        $actual = $this->subject->messages();
-
-        $this->assertEquals([], $actual);
     }
 }

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -17,7 +17,7 @@ class Location extends Model implements Auditable
 
     public function rooms(): HasMany
     {
-        return $this->hasMany(Room::class, 'room_id', 'id');
+        return $this->hasMany(Room::class, 'location_id', 'id');
     }
 
     public function parent(): HasOne

--- a/resources/views/template.blade.php
+++ b/resources/views/template.blade.php
@@ -143,7 +143,9 @@
 							<a class="dropdown-item" href={{ route('permission.index') }}>Permissions</a>
 							<a class="dropdown-item" href={{ route('role.index') }}>Roles</a>
 							<a class="dropdown-item" href={{ route('user.index') }}>Users</a>
-							<a class="dropdown-item" href={{ route('language.index') }}>Language</a>
+                                                        <a class="dropdown-item" href={{ route('language.index') }}>Language</a>
+
+                                                        <a class="dropdown-item" href={{ route('room.index') }}>{{ __('messages.rooms') }}</a>
 
 							<div class="dropdown-divider"></div>
 							<a class="dropdown-item" href={{ route('donation_type.index') }}>Donation types</a>

--- a/tests/Feature/Http/Controllers/RoomstateControllerTest.php
+++ b/tests/Feature/Http/Controllers/RoomstateControllerTest.php
@@ -54,4 +54,15 @@ final class RoomstateControllerTest extends TestCase
             'statusto' => 'A',
         ]);
     }
+
+    #[Test]
+    public function index_displays_housekeeping_page(): void
+    {
+        $user = $this->createUserWithPermission('show-room');
+
+        $response = $this->actingAs($user)->get(route('roomstate.index'));
+
+        $response->assertOk();
+        $response->assertSeeText('Housekeeping');
+    }
 }


### PR DESCRIPTION
## Summary
- fix `rooms()` relation in `Location`
- clean up `UpdateRoomRequest::messages`
- add link to room admin page
- add housekeeping index test
- implement checkout logic in `RetreatController`

## Testing
- `vendor/bin/phpunit tests/Feature/Http/Controllers/RoomstateControllerTest.php --stop-on-failure` *(fails: permission does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68815fae918083248d40e3565643f300